### PR TITLE
Add "score" key to metric result dict

### DIFF
--- a/evalem/_base/metrics.py
+++ b/evalem/_base/metrics.py
@@ -212,11 +212,18 @@ class JuryBasedMetric(Metric):
         predictions = format_to_jury(predictions)
         references = format_to_jury(references)
 
-        return self.scorer(
+        results = self.scorer(
             predictions=predictions,
             references=references,
             **kwargs,
         )
+        res = dict()
+        for k, v in results.items():
+            # for single metrics, just flatten the dict that has "score" key
+            if isinstance(v, dict) and "score" in v:
+                res["score"] = v.get("score", None)
+            res[k] = v
+        return res
 
 
 class PrecisionMetric(JuryBasedMetric, BasicMetric):


### PR DESCRIPTION
Since we're using Jury, the "score" key was nested inside a dictionary. So, now we've added the key to parent dict as well.

Example:

```python
from evalem import BaseMetrics

print(BaseMetrics.AccuracyMetric()(predictions=["a", "b"], references=["a", "a"]))

# previously, it gave: `{'total_items': 2, 'empty_items': 0, 'accuracy': {'score': 0.5}}`

# now, it give: `{'total_items': 2, 'empty_items': 0, 'score': 0.5, 'accuracy': {'score': 0.5}}`
```