### PR TITLE
Bugfix/llm as judge

### DIFF
--- a/evalem/_base/structures.py
+++ b/evalem/_base/structures.py
@@ -84,14 +84,14 @@ ImageTensor = Union[np.ndarray, torch.Tensor]
 # Represents type instance for any single downstream prediction
 PredictionInstance = Union[
     str,
-    Type[PredictionDTO],
+    PredictionDTO,
     dict,
     ImageTensor,
-    Type[ClassificationDTO],
+    ClassificationDTO,
 ]
 
 # Represents type instance for any single downstream reference/ground-truth
-ReferenceInstance = Union[str, Type[ReferenceDTO]]
+ReferenceInstance = Union[str, ReferenceDTO]
 
 SinglePredictionInstance = List[PredictionInstance]
 MultiplePredictionInstance = List[List[PredictionInstance]]

--- a/evalem/nlp/metrics/basics.py
+++ b/evalem/nlp/metrics/basics.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import dataclasses
+from typing import Tuple
 
 from ..._base.metrics import JuryBasedMetric
 from ..._base.structures import (
+    EvaluationPredictionInstance,
     EvaluationReferenceInstance,
     MetricResult,
     SinglePredictionInstance,
@@ -15,6 +17,13 @@ class ExactMatchMetric(JuryBasedMetric, NLPMetric):
     def __init__(self) -> None:
         super().__init__(metrics="exact_match")
 
+    def _flatten_multi_prediction_multi_reference(
+        self,
+        predictions: EvaluationPredictionInstance,
+        references: EvaluationReferenceInstance,
+    ) -> Tuple[EvaluationPredictionInstance, EvaluationReferenceInstance]:
+        raise NotImplementedError()
+
     def compute(
         self,
         predictions: SinglePredictionInstance,
@@ -24,7 +33,7 @@ class ExactMatchMetric(JuryBasedMetric, NLPMetric):
         # This metric doesn't support multi-reference format.
         # So, we flatten everything:
         # Single Prediction, Multi-Ref -> Single Prediction, Single-Ref
-        predictions, references = self._flatten_references(predictions, references)
+        predictions, references = self._flatten_instances(predictions, references)
         result = super().compute(
             predictions=predictions,
             references=references,

--- a/evalem/nlp/metrics/llm.py
+++ b/evalem/nlp/metrics/llm.py
@@ -54,6 +54,15 @@ class LLMAsJudgeMetric(NLPMetric):
         ```aggregation_type```: ```Optional[AggregationType]```
             Decides how to aggregate scores from the multiple judgement tries.
             Defaults to `AggregationType.MEAN` if not provided.
+        ```max_n```: ```Optional[int]```
+            If set, the total number of references or predictions per item.
+            This is to reduce LLM calls and thus minimizing scoring time.
+            Default behaviour is no truncation when set to `None` or less than 1.
+            will be truncated.
+            - If single reference, multiple predictions, total number of prediction will
+            be truncated
+            - If multiple reference, single prediction, total number of
+            reference will be truncated
         ```debug```:```bool```
             Boolean flag for debug-mode outputs
 
@@ -103,21 +112,29 @@ class LLMAsJudgeMetric(NLPMetric):
         temperature: float = 0.0,
         prompt: Optional[str] = None,
         aggregation_type: Optional[List[AggregationType]] = None,
+        max_n: Optional[int] = None,
         debug: bool = False,
     ) -> None:
         super().__init__(debug=debug)
+
+        model = self.__clean_model(model)
+        api_base = self.__clean_url(api_base)
         self.model = outlines.models.openai(
-            self.__clean_model(model),
+            model,
             base_url=api_base,
             api_key=api_key,
             config=OpenAIConfig(temperature=temperature),
         )
-        self.api_base = self.__clean_url(api_base)
+        self.api_base = api_base
         self.n_tries = n_tries or 1
         self.prompt = prompt or LLMAsJudgeMetric._prompt
         self.aggregation_type = aggregation_type or AggregationType.MEAN
-
         self._sanity_check_prmopt(self.prompt)
+        self.max_n = max_n or None
+        if self.max_n:
+            logger.warning(
+                f"Total number of predictions/references per item will be truncated based on `max_n` value.",
+            )
 
     def _sanity_check_prmopt(self, prompt: str) -> bool:
         if "{prediction}" not in prompt or "{reference}" not in prompt:
@@ -133,23 +150,26 @@ class LLMAsJudgeMetric(NLPMetric):
 
     def __clean_url(self, url: str) -> str:
         if not url.endswith("/v1"):
-            url = urljoin(url, "/v1")
+            url = urljoin(url, "v1")
         return url
 
     @staticmethod
     def _flatten_references(
         predictions,
         references,
+        max_n: Optional[int] = None,
     ) -> Tuple[EvaluationPredictionInstance, EvaluationReferenceInstance]:
+        if max_n is not None and max_n < 1:
+            max_n = None
         res = []
         for preds, refs in zip(predictions, references):
             # multiple predictions, single reference
             if isinstance(preds, SequenceType) and isinstance(refs, str):
-                res.extend(list(map(lambda p: (p, refs), preds)))
+                res.extend(list(map(lambda p: (p, refs), preds[slice(max_n)])))
 
             # single prediction, multiple references
             elif isinstance(preds, str) and isinstance(refs, SequenceType):
-                res.extend(list(map(lambda r: (preds, r), refs)))
+                res.extend(list(map(lambda r: (preds, r), refs[slice(max_n)])))
 
             # single prediction, single reference
             else:
@@ -165,7 +185,11 @@ class LLMAsJudgeMetric(NLPMetric):
         **kwargs,
     ) -> MetricResult:
         # make sure to flatten
-        predictions, references = self._flatten_references(predictions, references)
+        predictions, references = self._flatten_references(
+            predictions,
+            references,
+            max_n=self.max_n,
+        )
         if self.debug:
             logger.debug(f"Evaluating for {len(predictions)} predictions.")
         generator = outlines.generate.choice(self.model, ["0", "1"])


### PR DESCRIPTION
# Major Changes
- Add `max_n` parameter to truncate total number of predictions per instance in multi-prediction instances for LLMAsJudgeMetric
- Restructure of base classes to add `_flatten_instances`

# Minor Changes

- Add different method to check for different prediction/reference settings (single prediction single reference, multi-prediction single reference, etc.)